### PR TITLE
Tag flags docs

### DIFF
--- a/src/guides/aos/modules/handlers.md
+++ b/src/guides/aos/modules/handlers.md
@@ -1,1 +1,0 @@
-# Handlers


### PR DESCRIPTION
Adds docs for `--tag-name` and `--tag-value` in aos.