### PR TITLE
Update token specs & tutorial with forwarded tags

### DIFF
--- a/src/guides/aos/token.md
+++ b/src/guides/aos/token.md
@@ -136,16 +136,39 @@ Handlers.add('transfer', Handlers.utils.hasMatchingTag('Action', 'Transfer'), fu
       if the Cast tag is not set on the Transfer message
     ]] --
     if not msg.Tags.Cast then
-      -- Send Debit-Notice to the Sender
-      ao.send({
+      -- Debit-Notice message template, that is sent to the Sender of the transfer
+      local debitNotice = {
         Target = msg.From,
-        Tags = { Action = 'Debit-Notice', Recipient = msg.Tags.Recipient, Quantity = tostring(qty) }
-      })
-      -- Send Credit-Notice to the Recipient
-      ao.send({
-        Target = msg.Tags.Recipient,
-        Tags = { Action = 'Credit-Notice', Sender = msg.From, Quantity = tostring(qty) }
-      })
+        Action = 'Debit-Notice',
+        Recipient = msg.Recipient,
+        Quantity = tostring(qty),
+        Data = Colors.gray ..
+            "You transferred " ..
+            Colors.blue .. msg.Quantity .. Colors.gray .. " to " .. Colors.green .. msg.Recipient .. Colors.reset
+      }
+      -- Credit-Notice message template, that is sent to the Recipient of the transfer
+      local creditNotice = {
+        Target = msg.Recipient,
+        Action = 'Credit-Notice',
+        Sender = msg.From,
+        Quantity = tostring(qty),
+        Data = Colors.gray ..
+            "You received " ..
+            Colors.blue .. msg.Quantity .. Colors.gray .. " from " .. Colors.green .. msg.From .. Colors.reset
+      }
+
+      -- Add forwarded tags to the credit and debit notice messages
+      for tagName, tagValue in pairs(msg) do
+        -- Tags beginning with "X-" are forwarded
+        if string.sub(tagName, 1, 2) == "X-" then
+          debitNotice[tagName] = tagValue
+          creditNotice[tagName] = tagValue
+        end
+      end
+
+      -- Send Debit-Notice and Credit-Notice
+      ao.send(debitNotice)
+      ao.send(creditNotice)
     end
   else
     ao.send({

--- a/src/references/token.md
+++ b/src/references/token.md
@@ -91,7 +91,7 @@ Example response message:
 
 ### Transfer(Target, Quantity)
 
-If the sender has a sufficient balance, send the `Quantity` to the `Target`, issuing a `Credit-Notice` to the recipient and a `Debit-Notice` to the sender. If the sender has an insufficient balance, fail and notify the sender.
+If the sender has a sufficient balance, send the `Quantity` to the `Target`, issuing a `Credit-Notice` to the recipient and a `Debit-Notice` to the sender. The `Credit-` and `Debit-Notice` should forward any and all tags from the original `Transfer` message with the `X-` prefix. If the sender has an insufficient balance, fail and notify the sender.
 
 ```lua
 send({
@@ -99,7 +99,8 @@ send({
     Tags = {
         { name = "Action", value = "Transfer" },
         { name = "Recipient", value = "[ADDRESS]" },
-        { name = "Quantity", value = "100" }
+        { name = "Quantity", value = "100" },
+        { name = "X-[Forwarded Tag(s) Name]", value= "[VALUE]" }
     }
 })
 ```
@@ -112,7 +113,8 @@ ao.send({
     Tags = {
         { name = "Action", value = "Credit-Notice" },
         { name = "Sender", value = "[ADDRESS]" },
-        { name = "Quantity", value = "100"}
+        { name = "Quantity", value = "100"},
+        { name = "X-[Forwarded Tag(s) Name]", value= "[VALUE]" }
     }
 })
 ```
@@ -174,7 +176,8 @@ ao.send({
         { name = "Action", value = "Credit-Notice" },
         { name = "Quantity", value = "100"},
         { name = "Source-Token", value = "[ADDRESS]" },
-        { name = "Parent-Token", value = "[ADDRESS]" }
+        { name = "Parent-Token", value = "[ADDRESS]" },
+        { name = "X-[Forwarded Tag(s) Name]", value= "[VALUE]" }
     }
 })
 ```


### PR DESCRIPTION
This PR updates the token specs with the forwarded tags (for transfers) specification. Let me know if I need to open this PR somewhere else as well for a specs update. 
This should only be merged after [#221](https://github.com/permaweb/aos/pull/221) is finalized.