### PR TITLE
add info on betteridea to guides and editor setup pages

### DIFF
--- a/src/guides/0rbit/post-request.md
+++ b/src/guides/0rbit/post-request.md
@@ -3,7 +3,7 @@ prev:
   text: "Get ANY Data"
   link: "/guides/0rbit/get-request"
 next:
-  text: "betteridea"
+  text: "BetterIDEa IDE"
   link: "../betteridea/index.md"
 ---
 

--- a/src/guides/0rbit/post-request.md
+++ b/src/guides/0rbit/post-request.md
@@ -3,8 +3,8 @@ prev:
   text: "Get ANY Data"
   link: "/guides/0rbit/get-request"
 next:
-  text: "Concepts"
-  link: "/concepts/index"
+  text: "betteridea"
+  link: "../betteridea/index.md"
 ---
 
 # Post Data

--- a/src/guides/aos/editor.md
+++ b/src/guides/aos/editor.md
@@ -21,3 +21,18 @@ Install the [sumneko.lua](https://marketplace.visualstudio.com/items?itemName=su
 1. Verify that your editor supports the [language server protocol](https://microsoft.github.io/language-server-protocol/implementors/tools/)
 2. Install Lua Language Server by following the instructions at [luals.github.io](https://luals.github.io/#install)
 3. Install the "ao" addon to the language server
+
+## BetterIDEa IDE
+
+[BetterIDEa](https://ide.betteridea.dev) is a custom web based IDE for developing on ao.
+
+It offers a built in Lua language server with ao definitions, so you don't need to install anything. Just open the IDE and start coding!
+
+Features include:
+
+- Code completion
+- Cell based notebook ui for rapid development
+- Easy process management
+- Markdown and Latex cell support
+- Share projects with anyone through ao processes
+- Tight integration with [ao package manager](https://apm.betteridea.dev)

--- a/src/guides/aos/editor.md
+++ b/src/guides/aos/editor.md
@@ -22,7 +22,7 @@ Install the [sumneko.lua](https://marketplace.visualstudio.com/items?itemName=su
 2. Install Lua Language Server by following the instructions at [luals.github.io](https://luals.github.io/#install)
 3. Install the "ao" addon to the language server
 
-## BetterIDEa IDE
+## BetterIDEa
 
 [BetterIDEa](https://ide.betteridea.dev) is a custom web based IDE for developing on ao.
 
@@ -36,3 +36,5 @@ Features include:
 - Markdown and Latex cell support
 - Share projects with anyone through ao processes
 - Tight integration with [ao package manager](https://apm.betteridea.dev)
+
+Read detailed information about the various features and integrations of the ide in the [documentation](https://docs.betteridea.dev).

--- a/src/guides/betteridea/index.md
+++ b/src/guides/betteridea/index.md
@@ -1,0 +1,25 @@
+---
+prev:
+  text: "Get ANY Data"
+  link: "/guides/0rbit/get-request"
+next:
+  text: "aos"
+  link: "./aos/index"
+---
+
+# BetterIDEa
+
+[BetterIDEa](https://ide.betteridea.dev) is a custom web based IDE for developing on ao.
+
+It offers a built in Lua language server with ao definitions, so you don't need to install anything. Just open the IDE and start coding!
+
+Features include:
+
+- Code completion
+- Cell based notebook ui for rapid development
+- Easy process management
+- Markdown and Latex cell support
+- Share projects with anyone through ao processes
+- Tight integration with [ao package manager](https://apm.betteridea.dev)
+
+Read detailed information about the various features and integrations of the ide in the [documentation](https://docs.betteridea.dev/).

--- a/src/guides/betteridea/index.md
+++ b/src/guides/betteridea/index.md
@@ -1,10 +1,10 @@
 ---
 prev:
-  text: "Get ANY Data"
-  link: "/guides/0rbit/get-request"
+  text: "0rbit"
+  link: "../0rbit/index"
 next:
   text: "aos"
-  link: "./aos/index"
+  link: "../aos/index"
 ---
 
 # BetterIDEa
@@ -22,4 +22,4 @@ Features include:
 - Share projects with anyone through ao processes
 - Tight integration with [ao package manager](https://apm.betteridea.dev)
 
-Read detailed information about the various features and integrations of the ide in the [documentation](https://docs.betteridea.dev/).
+Read detailed information about the various features and integrations of the ide in the [documentation](https://docs.betteridea.dev).

--- a/src/guides/index.md
+++ b/src/guides/index.md
@@ -16,4 +16,4 @@ These guides are designed to help you navigate ao and aos, and to help you build
 - [aos](aos/index)
 - [aoconnect](aoconnect/aoconnect)
 - [0rbit](0rbit/index)
-- [betteridea](betteridea/index)
+- [BetterIDEa IDE](betteridea/index)

--- a/src/guides/index.md
+++ b/src/guides/index.md
@@ -16,3 +16,4 @@ These guides are designed to help you navigate ao and aos, and to help you build
 - [aos](aos/index)
 - [aoconnect](aoconnect/aoconnect)
 - [0rbit](0rbit/index)
+- [betteridea](betteridea/index)

--- a/src/references/editor-setup.md
+++ b/src/references/editor-setup.md
@@ -23,3 +23,18 @@ If you don't want to do this process for each of your workspaces, you can copy t
 1. Verify that your editor supports the [language server protocol](https://microsoft.github.io/language-server-protocol/implementors/tools/)
 2. Install Lua Language Server by following the instructions at [luals.github.io](https://luals.github.io/#install)
 3. Install the "ao" addon to the language server
+
+## BetterIDEa IDE
+
+[BetterIDEa](https://ide.betteridea.dev) is a custom web based IDE for developing on ao.
+
+It offers a built in Lua language server with ao definitions, so you don't need to install anything. Just open the IDE and start coding!
+
+Features include:
+
+- Code completion
+- Cell based notebook ui for rapid development
+- Easy process management
+- Markdown and Latex cell support
+- Share projects with anyone through ao processes
+- Tight integration with [ao package manager](https://apm.betteridea.dev)

--- a/src/references/editor-setup.md
+++ b/src/references/editor-setup.md
@@ -1,6 +1,6 @@
 # Editor setup
 
-Remembering all the built in ao functions and utilites can sometimes be hard. To enhance your developer experience, it is recommended to install the [Lua Language Server](https://luals.github.io) extension into your favorite text editor and add the [ao addon](https://github.com/martonlederer/ao-definitions). It supports all built in aos [modules](../guides/aos/index.md) and [globals](../guides/aos/intro#globals).
+Remembering all the built in ao functions and utilites can sometimes be hard. To enhance your developer experience, it is recommended to install the [Lua Language Server](https://luals.github.io) extension into your favorite text editor and add the [ao addon](https://github.com/martonlederer/ao-definitions). It supports all built in aos [modules](../aos/modules/index) and [globals](../aos/intro#globals).
 
 ## VS Code
 
@@ -14,9 +14,7 @@ Install the [sumneko.lua](https://marketplace.visualstudio.com/items?itemName=su
 > Lua: Open Addon Manager
 ```
 
-1. Open a workspace first. In the Addon Manager, search for "ao", it should be the first result. Click "Enable" and enjoy autcomplete!
-
-If you don't want to do this process for each of your workspaces, you can copy the `Lua.workspace.library` object from the generated workspace `settings.json` file to your global `settings.json` file.
+4. In the Addon Manager, search for "ao", it should be the first result. Click "Enable" and enjoy autcomplete!
 
 ## Other editors
 
@@ -24,7 +22,7 @@ If you don't want to do this process for each of your workspaces, you can copy t
 2. Install Lua Language Server by following the instructions at [luals.github.io](https://luals.github.io/#install)
 3. Install the "ao" addon to the language server
 
-## BetterIDEa IDE
+## BetterIDEa
 
 [BetterIDEa](https://ide.betteridea.dev) is a custom web based IDE for developing on ao.
 
@@ -38,3 +36,5 @@ Features include:
 - Markdown and Latex cell support
 - Share projects with anyone through ao processes
 - Tight integration with [ao package manager](https://apm.betteridea.dev)
+
+Read detailed information about the various features and integrations of the ide in the [documentation](https://docs.betteridea.dev).

--- a/src/references/editor-setup.md
+++ b/src/references/editor-setup.md
@@ -1,6 +1,6 @@
 # Editor setup
 
-Remembering all the built in ao functions and utilites can sometimes be hard. To enhance your developer experience, it is recommended to install the [Lua Language Server](https://luals.github.io) extension into your favorite text editor and add the [ao addon](https://github.com/martonlederer/ao-definitions). It supports all built in aos [modules](../aos/modules/index) and [globals](../aos/intro#globals).
+Remembering all the built in ao functions and utilites can sometimes be hard. To enhance your developer experience, it is recommended to install the [Lua Language Server](https://luals.github.io) extension into your favorite text editor and add the [ao addon](https://github.com/martonlederer/ao-definitions). It supports all built in aos [modules](../guides/aos/modules/index.md) and [globals](../guides/aos/intro.md#globals).
 
 ## VS Code
 


### PR DESCRIPTION
In addition to vscode and cli usage, have also added information on the web based ide - [betteridea](https://ide.betteridea.dev) to guides and editor setup sections.

Please let me know if any changes are needed

Thanks