### PR TITLE
Use updated scheduler ID

### DIFF
--- a/src/guides/aoconnect/spawning-processes.md
+++ b/src/guides/aoconnect/spawning-processes.md
@@ -6,10 +6,18 @@ In order to spawn a Process you must have the TXID of an ao Module that has been
 
 You must also have the wallet address of a Scheduler Unit (SU). This specified SU will act as the scheduler for this Process. This means that all nodes in the system can tell that they need to read and write to this SU for this Process. You can use the address below.
 
-## Wallet address of an available Scheduler
+### Wallet address of an available Scheduler
 
 ```lua
 _GQ33BkPtZrqxA84vM8Zk-N2aO0toNNu_C-l-rawrBA
+```
+
+In addition, in order to receive messages from other processes an `Authority` tag must be supplied with the wallet address of an authorised Messaging Unit (MU).
+
+### Wallet address of the testnet MU
+
+```lua
+fcoN_xJeisVsPXA-trzVAuIiqO3ydLQxM-L4XbrQKzY
 ```
 
 ## Spawning a Process in NodeJS
@@ -35,7 +43,7 @@ const processId = await spawn({
     for tags that may effect its computation.
   */
   tags: [
-    { name: "Your-Tag-Name-Here", value: "your-tag-value" },
+    { name: "Authority", value: "fcoN_xJeisVsPXA-trzVAuIiqO3ydLQxM-L4XbrQKzY" },
     { name: "Another-Tag", value: "another-value" },
   ],
 });
@@ -58,7 +66,7 @@ const processId = await spawn({
     for tags that may effect its computation.
   */
   tags: [
-    { name: "Your-Tag-Name-Here", value: "your-tag-value" },
+    { name: "Authority", value: "fcoN_xJeisVsPXA-trzVAuIiqO3ydLQxM-L4XbrQKzY" },
     { name: "Another-Tag", value: "another-value" },
   ],
 });

--- a/src/guides/aoconnect/spawning-processes.md
+++ b/src/guides/aoconnect/spawning-processes.md
@@ -9,7 +9,7 @@ You must also have the wallet address of a Scheduler Unit (SU). This specified S
 ## Wallet address of an available Scheduler
 
 ```lua
-TZ7o7SIZ06ZEJ14lXwVtng1EtSx60QkPy-kh-kdAXog
+_GQ33BkPtZrqxA84vM8Zk-N2aO0toNNu_C-l-rawrBA
 ```
 
 ## Spawning a Process in NodeJS

--- a/src/zh/guides/aoconnect/spawning-processes.md
+++ b/src/zh/guides/aoconnect/spawning-processes.md
@@ -9,7 +9,7 @@
 ## 调度器的钱包地址
 
 ```sh
-TZ7o7SIZ06ZEJ14lXwVtng1EtSx60QkPy-kh-kdAXog
+_GQ33BkPtZrqxA84vM8Zk-N2aO0toNNu_C-l-rawrBA
 ```
 
 ## 在 NodeJS 中创建一个进程
@@ -27,7 +27,7 @@ const processId = await spawn({
   // The Arweave TXID of the ao Module
   module: "module TXID",
   // The Arweave wallet address of a Scheduler Unit
-  scheduler: "TZ7o7SIZ06ZEJ14lXwVtng1EtSx60QkPy-kh-kdAXog",
+  scheduler: "_GQ33BkPtZrqxA84vM8Zk-N2aO0toNNu_C-l-rawrBA",
   // A signer function containing your wallet
   signer: createDataItemSigner(wallet),
   /*
@@ -50,7 +50,7 @@ const processId = await spawn({
   // The Arweave TXID of the ao Module
   module: "module TXID",
   // The Arweave wallet address of a Scheduler Unit
-  scheduler: "TZ7o7SIZ06ZEJ14lXwVtng1EtSx60QkPy-kh-kdAXog",
+  scheduler: "_GQ33BkPtZrqxA84vM8Zk-N2aO0toNNu_C-l-rawrBA",
   // A signer function containing your wallet
   signer: createDataItemSigner(globalThis.arweaveWallet),
   /*

--- a/src/zh/guides/aoconnect/spawning-processes.md
+++ b/src/zh/guides/aoconnect/spawning-processes.md
@@ -35,7 +35,7 @@ const processId = await spawn({
     for tags that may effect its computation.
   */
   tags: [
-    { name: "Your-Tag-Name-Here", value: "your-tag-value" },
+    { name: "Authority", value: "fcoN_xJeisVsPXA-trzVAuIiqO3ydLQxM-L4XbrQKzY" },
     { name: "Another-Tag", value: "another-value" },
   ],
 });
@@ -58,7 +58,7 @@ const processId = await spawn({
     for tags that may effect its computation.
   */
   tags: [
-    { name: "Your-Tag-Name-Here", value: "your-tag-value" },
+    { name: "Authority", value: "fcoN_xJeisVsPXA-trzVAuIiqO3ydLQxM-L4XbrQKzY" },
     { name: "Another-Tag", value: "another-value" },
   ],
 });


### PR DESCRIPTION
Spawning with the old one results in dead processes, e.g.
https://www.ao.link/#/entity/eGgsCN7pEb4lb8ZKVbwbOBvRBAwMLDsgeEA3db9oMv0

<img width="513" alt="Screenshot 2024-09-25 at 8 25 24 PM" src="https://github.com/user-attachments/assets/cd7e8a31-ca01-4a16-96a7-936e3ea94fef">''

Also, added info for `Authority` tag