### PR TITLE
Fix minor capitalization issue that breaks tutorial experience

### DIFF
--- a/src/tutorials/begin/messaging.md
+++ b/src/tutorials/begin/messaging.md
@@ -211,7 +211,7 @@ Send({ Target = Morpheus, Data = "Code: rabbithole", Action = "Unlock" })
 **Read the message from Morpheus:**
 
 ```lua
-Inbox[#Inbox].data
+Inbox[#Inbox].Data
 ```
 
 <div id="step-7-2"></div>


### PR DESCRIPTION
Minor, but `Inbox[#Inbox].data` doesn't work, whereas `Inbox[#Inbox].Data` does.