### PR TITLE
Update Cookbook to use arweave.net gateway

### DIFF
--- a/src/releasenotes/aos-2_0_0.md
+++ b/src/releasenotes/aos-2_0_0.md
@@ -5,7 +5,7 @@
 ## Install instructions for AOS 2.0.0
 
 ```shell
-npm i -g https://get_ao.g8way.io
+npm i -g https://get_ao.arweave.net
 ```
 
 > Use `.update` to update earlier aos processes. See the **note** below on what features are not supported on earlier processes.


### PR DESCRIPTION
The g8tway.io domain is heavily flagged as a virus domain. he quickest solution is to use a different gateway while I clear that one up.