### PR TITLE
update to arweave.net gateway

### DIFF
--- a/src/tutorials/bots-and-games/ao-effect.md
+++ b/src/tutorials/bots-and-games/ao-effect.md
@@ -29,7 +29,7 @@ To join this global escapade, you'll need to set things up. Don't worry, it's as
 Fire up your terminal and run:
 
 ```bash
-npm i -g https://get_ao.g8way.io
+npm i -g https://get_ao.arweave.net
 ```
 
 2. **Launch aos**


### PR DESCRIPTION
The g8tway.io domain is heavily flagged as a virus domain. he quickest solution is to use a different gateway while I clear that one up.