### PR TITLE
update to arweave.net gateway

### DIFF
--- a/src/tutorials/begin/preparations.md
+++ b/src/tutorials/begin/preparations.md
@@ -28,7 +28,7 @@ Though it's not required, we do recommend installing the [ao addon](../../refere
 Once you have NodeJS on your machine, all you need to do is install aos and run it:
 
 ```sh
-npm i -g https://get_ao.g8way.io
+npm i -g https://get_ao.arweave.net
 ```
 
 After installation, we can simply run the command itself to start a new aos process!


### PR DESCRIPTION
The g8tway.io domain is heavily flagged as a virus domain. he quickest solution is to use a different gateway while I clear that one up.