### PR TITLE
g8way.io switch to arweave.net

### DIFF
--- a/src/welcome/getting-started.md
+++ b/src/welcome/getting-started.md
@@ -14,7 +14,7 @@ The local client of aos is super simple to install. Just make sure you have:
 Once you have NodeJS on your machine, all you need to do is install aos and run it:
 
 ```sh
-npm i -g https://get_ao.g8way.io
+npm i -g https://get_ao.arweave.net
 ```
 
 After installation, we can simply run the command itself to start a new aos process!


### PR DESCRIPTION
The g8tway.io domain is heavily flagged as a virus domain. he quickest solution is to use a different gateway while I clear that one up.