### PR TITLE
fix: update landing page callouts with correct links and descriptions

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -13,15 +13,15 @@ hero:
 
 features:
   - title: AO-Core
-    details: The protocol powering decentralized computation
-    link: /welcome/concepts
+    details: Learn the fundamentals of AO's decentralized compute protocol
+    link: /welcome/index.html
 
-  - title: HyperBEAM
-    details: Build with instant HTTP state access
-    link: /welcome/
+  - title: AO on HyperBEAM
+    details: Build scalable applications with instant HTTP state access
+    link: /welcome/building.html
 
-  - title: Arweave Storage
-    details: Permanent computation with mathematical guarantees
+  - title: HyperBEAM Docs
+    details: Explore advanced patterns and reference documentation
     link: /welcome/concepts
 ---
 


### PR DESCRIPTION
## Summary
- Updated AO-Core callout to link to `/welcome/index.html` instead of `/welcome/concepts`
- Retitled HyperBEAM to "AO on HyperBEAM" and linked to `/welcome/building.html`
- Replaced "Arweave Storage" with "HyperBEAM Docs" as the final callout
- Improved all descriptions to be more helpful, accurate, and consistent in length

## Changes
- Fixed incorrect navigation links for better user experience
- Updated callout titles to better reflect content
- Enhanced descriptions to provide clearer guidance on what users will find